### PR TITLE
Use Google OpenID Connect for auth

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,6 @@ gunicorn==19.4.5
 psycopg2==2.6.1
 dj-database-url==0.4.0
 python-decouple==3.0
+django-googleauth==2.1
+PyJWT==0.4.1
+requests==2.5.1

--- a/shielddash/api/views.py
+++ b/shielddash/api/views.py
@@ -1,5 +1,5 @@
 from rest_framework.exceptions import ParseError
-from rest_framework.permissions import AllowAny
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -8,8 +8,7 @@ from shielddash.api.forms import Form
 
 
 class RetentionView(APIView):
-    authentication_classes = []
-    permission_classes = [AllowAny]
+    permission_classes = [IsAuthenticated]
 
     def perform_authentication(self, request):
         pass

--- a/shielddash/settings.py
+++ b/shielddash/settings.py
@@ -31,18 +31,54 @@ DEBUG = config('DEBUG', default=False, cast=bool)
 
 ALLOWED_HOSTS = ['*']
 
+DOMAIN = config('DOMAIN', default='localhost:8000')
 
-# Application definition
+STATIC_ROOT = config('STATIC_ROOT', default=os.path.join(BASE_DIR, 'static'))
+STATIC_URL = config('STATIC_URL', '/static/')
 
 INSTALLED_APPS = [
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'django.contrib.staticfiles',
+
+    'django.contrib.admin',
+    'django.contrib.sessions',
+    'django.contrib.messages',
+
+    'rest_framework',
+    'googleauth',
     'shielddash.api',
 ]
 
 MIDDLEWARE_CLASSES = [
     'django.middleware.security.SecurityMiddleware',
     'django.middleware.common.CommonMiddleware',
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'shielddash.middleware.CORSMiddleware'
+]
+
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'APP_DIRS': True,
+        'DIRS': [os.path.join(BASE_DIR, 'templates')],
+        'OPTIONS': {
+            'context_processors': [
+                'django.contrib.auth.context_processors.auth',
+                'django.template.context_processors.debug',
+                'django.template.context_processors.i18n',
+                'django.template.context_processors.media',
+                'django.template.context_processors.static',
+                'django.template.context_processors.tz',
+                'django.contrib.messages.context_processors.messages',
+                'social.apps.django_app.context_processors.backends',
+                'social.apps.django_app.context_processors.login_redirect',
+                'shielddash.api.context_processors.google_auth_key',
+            ],
+        }
+    }
 ]
 
 ROOT_URLCONF = 'shielddash.urls'
@@ -76,10 +112,16 @@ USE_L10N = False
 
 USE_TZ = False
 
+AUTHENTICATION_BACKENDS = (
+    'googleauth.backends.GoogleAuthBackend',
+)
 
 REST_FRAMEWORK = {
-    'DEFAULT_AUTHENTICATION_CLASSES': (),
-    'DEFAULT_RENDERER_CLASSES': (
-        'rest_framework.renderers.JSONRenderer',
-    ),
 }
+
+GOOGLEAUTH_CLIENT_ID = config('GOOGLEAUTH_CLIENT_ID', '676697640342-o9mhtndrj60dk7jksdmmunetfmuqng4q.apps.googleusercontent.com')
+GOOGLEAUTH_CLIENT_SECRET = config('GOOGLEAUTH_CLIENT_SECRET', '_HoDDGIq_ZrhBiES-ozIhUgh')
+GOOGLEAUTH_APPS_DOMAIN = 'mozilla.com'
+GOOGLEAUTH_CALLBACK_DOMAIN = DOMAIN
+GOOGLEAUTH_USE_HTTPS = (DOMAIN != 'localhost:8000')
+LOGIN_REDIRECT_URL = '/retention?start=20160101&end=20160102'

--- a/shielddash/urls.py
+++ b/shielddash/urls.py
@@ -1,21 +1,9 @@
-"""shielddash URL Configuration
-
-The `urlpatterns` list routes URLs to views. For more information please see:
-    https://docs.djangoproject.com/en/1.9/topics/http/urls/
-Examples:
-Function views
-    1. Add an import:  from my_app import views
-    2. Add a URL to urlpatterns:  url(r'^$', views.home, name='home')
-Class-based views
-    1. Add an import:  from other_app.views import Home
-    2. Add a URL to urlpatterns:  url(r'^$', Home.as_view(), name='home')
-Including another URLconf
-    1. Import the include() function: from django.conf.urls import url, include
-    2. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
-"""
-from django.conf.urls import url
+from django.conf.urls import include, url
 from shielddash.api.views import RetentionView
+from django.contrib import admin
 
 urlpatterns = [
     url(r'^retention/', RetentionView.as_view(), name='retention'),
+    url(r'^admin/', include(admin.site.urls)),
+    url(r'^auth/', include('googleauth.urls')),
 ]


### PR DESCRIPTION
This is the old redirect-based OAuth2 flow we all know and... well, we know about it anyway.

It relies on cookie-based auth for API requests currently, we can do some kind of token thing if needed.
